### PR TITLE
Fixed addon coordinates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,7 @@ The add-on corresponding to the used platform version will be installed.
 
 4. Paste the add-on coordinates in the corresponding field as follows:
 
- `com.haulmont.addon.saml:saml-global:<add-on version>`
+ `com.haulmont.addon.saml:saml-addon-global:<add-on version>`
 
  where `<add-on version>` is compatible with the used version of the CUBA platform.
 


### PR DESCRIPTION
In the demo project, the coordinates were different than those mentioned in the Readme.md. Used the coordinates from the demo project and everything went fine. This fix should be applied to the [website](https://www.cuba-platform.com/marketplace/saml/) also.